### PR TITLE
Change default path of language identifier binary

### DIFF
--- a/ftlangdetect/detect.py
+++ b/ftlangdetect/detect.py
@@ -5,7 +5,7 @@ import fasttext
 import wget
 
 models = {"low_mem": None, "high_mem": None}
-FTLANG_CACHE = os.getenv("FTLANG_CACHE", "/tmp/fasttext-langdetect")
+FTLANG_CACHE = os.getenv("FTLANG_CACHE", os.path.dirname(__file__))
 
 
 def download_model(name):


### PR DESCRIPTION
Hi, I think having `os.path.dirname(__file__)` as the default directory for storing the binary would be a better default than `"/tmp/fasttext-langdetect"`, since some systems might not have a working tmp directory. In any case, thanks for your library, it has been useful to me.