### PR TITLE
Update setup.py: use wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='fasttext-langdetect',
       author='Zafer Cavdar',
       author_email='zafercavdar@yahoo.com',
       install_requires=[
-          "fasttext>=0.9.1",
+          "fasttext-wheel>=0.9.1",
           "requests>=2.22.0",
       ],
       license='MIT',


### PR DESCRIPTION
Avoid dependency on python3-devel and pybind11 by using precompiled dependency.