### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
 To avoid below error.
 Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead.